### PR TITLE
Fix #32 create PlantnetBTP

### DIFF
--- a/core/BET.js
+++ b/core/BET.js
@@ -46,6 +46,7 @@ class BotEnTrain {
       try {
           let remoteAdd = bet.getRemoteAddress(req);
           let apiToken = req.get('API-TOKEN');
+          let pluginName = req.get('PLUGIN-NAME');
           let doSimulate = bet.tokenSimulation && apiToken === bet.tokenSimulation;
           let doAction = !doSimulate && bet.tokenAction && apiToken === bet.tokenAction;
           if (!doSimulate && !doAction) {
@@ -55,7 +56,7 @@ class BotEnTrain {
             });
             return;
           }
-          bet.botEngine.process(remoteAdd, doSimulate, (err, pluginResult) => {
+          bet.botEngine.process(remoteAdd, doSimulate, pluginName, (err, pluginResult) => {
             let msg = err ? err : pluginResult;
             res.status(err ? err.status : 200).json({
                         success: err ? false : true,
@@ -73,7 +74,7 @@ class BotEnTrain {
     }
 
     getSecondeId() {
-      return dateFormat(getDate(), "yyyymmddHHMMss");
+      return dateFormat(this.getDate(), "yyyymmddHHMMss");
     }
 
     getDate() {

--- a/core/MyPlantnetClient.js
+++ b/core/MyPlantnetClient.js
@@ -1,0 +1,134 @@
+/*jshint esversion: 6 */
+var log4js = require('log4js');
+const fs = require('fs');
+const superagent = require('superagent');
+const queryString = require('querystring');
+
+const MYPLANTNET_API_URL = 'https://my-api.plantnet.org/v2/identify/all';
+
+// Pl@ntNet API : https://github.com/plantnet/my.plantnet/blob/master/README.md
+class MyPlantnetClient {
+
+  constructor() {
+    this.isAvailable = false;
+    this.logger = log4js.getLogger();
+    this.logger.setLevel('INFO'); // DEBUG will show api params
+
+    try {
+        if (!process.env.MYPLANTNET_API_PRIVATE_KEY) {
+            throw "MyPlantnet, please setup your environment";
+        }
+        this.apiKey = process.env.MYPLANTNET_API_PRIVATE_KEY;
+        this.isAvailable = true;
+        this.logInfo("available");
+    } catch (exception) {
+        this.logError(exception);
+    }
+  }
+
+  isReady() {
+    return this.isAvailable;
+  }
+
+  identify(imageUrl, doSimulate, cb) {
+      this.logInfo("identify following image : " + imageUrl);
+      /*
+      if (doSimulate) {
+        let simulatedAnswer = fs.readFileSync('./core/data/plantNetFrenchResponse.json');
+        cb(false, JSON.parse(simulatedAnswer));
+        return;
+      }
+      */
+      // https://my.plantnet.org/account/doc // v2
+      superagent.get(MYPLANTNET_API_URL)
+      .query({
+             "images": [imageUrl, imageUrl],
+             "organs": ["flower","leaf"],
+             "include-related-images": true,
+             "lang": "fr",
+            "api-key": this.apiKey,
+         })
+      .end((err, res) => {
+        if (err) {
+          let errStatus = err.status;
+          let errError = err.message;
+          let errDetails = err.response.text;
+          let errResult = "Pla@ntnet identify error (" + errStatus + ") " + errError;
+          this.logError(errResult + " - details:" + errDetails);
+          cb(errResult);
+          return;
+        }
+        cb(false, res.body);
+      });
+  }
+
+  resultInfoOf(aResult) {
+    if (!aResult) {
+      return "";
+    }
+    let score = aResult.score;
+    let scorePercent = (score * 100).toFixed(2);
+    let scientificName = aResult.species ? aResult.species.scientificNameWithoutAuthor : false;
+    let family =  aResult.species && aResult.species.family ? aResult.species.family.scientificNameWithoutAuthor : false;
+    let commonNamesArray = aResult.species ? aResult.species.commonNames : false;
+
+    let infoOf = `Score de ${scorePercent}%`;
+    if (scientificName) {
+      infoOf += ` - nom scientifique : ${scientificName}`;
+    }
+    if (family) {
+      infoOf += ` - famille: ${family}`;
+    }
+    if (this.arrayWithContent(commonNamesArray)) {
+        let commonNamesArrayStr = commonNamesArray.join(', ');
+        infoOf += ` - noms communs : ${commonNamesArrayStr}`;
+    }
+    return infoOf;
+  }
+
+  resultImageOf(aResult) {
+    if (!aResult) {
+      return false;
+    }
+    let firstImage = aResult.images && aResult.images[0] ? aResult.images[0] : false;
+    if (!firstImage) {
+      return false;
+    }
+    let firstImageUrl = firstImage.url ? firstImage.url : {};
+    let imageUrl = firstImageUrl.o ? firstImageUrl.o : firstImageUrl.m ? firstImageUrl.m : firstImageUrl.s;
+    let imageCredits = firstImage.citation ? firstImage.citation : firstImage.author;
+    let imageOrgan = firstImage.organ === 'flower' ? "fleur" :
+                     firstImage.organ === 'leaf' ? 'feuille' : false;
+    let imageOf = imageCredits;
+    if (imageOrgan) {
+        imageOf = `${imageOrgan} - ${imageOf}`;
+    }
+    return `${imageOf}\n${imageUrl}`;
+  }
+
+  hasScoredResult(plantnetResponse, minimalScore) {
+    if (!plantnetResponse || !plantnetResponse.results) {
+        return false;
+    }
+    let resArray = plantnetResponse.results;
+    resArray = resArray.filter( (res) => { return (res.score > minimalScore); } );
+    return resArray.length > 0 ? resArray[0] : false;
+  }
+
+  arrayWithContent(arr) {
+    return (Array.isArray(arr) && arr.length > 0);
+  }
+
+  logError(msg) {
+    this.logger.error("MyPlantnetClient | " + msg);
+  }
+  logInfo(msg) {
+    this.logger.info("MyPlantnetClient | " + msg);
+  }
+  logDebug(msg) {
+    this.logger.debug("MyPlantnetClient | " + msg);
+  }
+}
+
+
+module.exports = MyPlantnetClient;

--- a/core/data/plantNetFrenchResponse.json
+++ b/core/data/plantNetFrenchResponse.json
@@ -1,0 +1,283 @@
+{
+    "query": {
+        "project": "best",
+        "images": ["https://pbs.twimg.com/media/EIxl61NWoAA4gQ7?format=jpg&name=4096x4096", "https://pbs.twimg.com/media/EIxl61NWoAA4gQ7?format=jpg&name=4096x4096"],
+        "organs": ["flower", "leaf"]
+    },
+    "language": "fr",
+    "preferedReferential": "the-plant-list",
+    "results": [{
+            "score": 0.8508715629577637,
+            "species": {
+                "scientificNameWithoutAuthor": "Pancratium maritimum",
+                "scientificNameAuthorship": "L.",
+                "genus": {
+                    "scientificNameWithoutAuthor": "Pancratium",
+                    "scientificNameAuthorship": ""
+                },
+                "family": {
+                    "scientificNameWithoutAuthor": "Amaryllidaceae",
+                    "scientificNameAuthorship": ""
+                },
+                "commonNames": ["Lis de mer", "Lis des sables", "Lis maritime"]
+            },
+            "images": [{
+                    "organ": "flower",
+                    "author": "Tela Botanica − Josette PUYO",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1347129130000,
+                        "string": "8 septembre 2012"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/009f5bb5bddc80c43c0e05c637ae911d8c2f8b9b",
+                        "m": "https://bs.floristic.org/v1/image/m/009f5bb5bddc80c43c0e05c637ae911d8c2f8b9b",
+                        "s": "https://bs.floristic.org/v1/image/s/009f5bb5bddc80c43c0e05c637ae911d8c2f8b9b"
+                    },
+                    "citation": "Tela Botanica − Josette PUYO / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "leaf",
+                    "author": "Bas Bas",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1566926841649,
+                        "string": "27 août 2019"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/b3ba04d67a4113ccc0a0b97502fab7650464a149",
+                        "m": "https://bs.floristic.org/v1/image/m/b3ba04d67a4113ccc0a0b97502fab7650464a149",
+                        "s": "https://bs.floristic.org/v1/image/s/b3ba04d67a4113ccc0a0b97502fab7650464a149"
+                    },
+                    "citation": "Bas Bas / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "EOL − Nevit Dilmen",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271698168,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/07b05fb6e495d5acf7dd92c5b589e54db89a9ae3",
+                        "m": "https://bs.floristic.org/v1/image/m/07b05fb6e495d5acf7dd92c5b589e54db89a9ae3",
+                        "s": "https://bs.floristic.org/v1/image/s/07b05fb6e495d5acf7dd92c5b589e54db89a9ae3"
+                    },
+                    "citation": "EOL − Nevit Dilmen / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Jean-Pascal MILCENT",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1253778914000,
+                        "string": "24 septembre 2009"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/9ebcdaeed031c24bc83db7b06e6db02d4a473f1c",
+                        "m": "https://bs.floristic.org/v1/image/m/9ebcdaeed031c24bc83db7b06e6db02d4a473f1c",
+                        "s": "https://bs.floristic.org/v1/image/s/9ebcdaeed031c24bc83db7b06e6db02d4a473f1c"
+                    },
+                    "citation": "Tela Botanica − Jean-Pascal MILCENT / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "EOL − Nevit Dilmen",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271698168,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/1660404e4f04fa3b8dfb1a3fa1fb9c199cd19da9",
+                        "m": "https://bs.floristic.org/v1/image/m/1660404e4f04fa3b8dfb1a3fa1fb9c199cd19da9",
+                        "s": "https://bs.floristic.org/v1/image/s/1660404e4f04fa3b8dfb1a3fa1fb9c199cd19da9"
+                    },
+                    "citation": "EOL − Nevit Dilmen / Pl@ntNet, cc-by-sa"
+                }
+            ],
+            "gbif": {
+                "id": "2853283"
+            }
+        }, {
+            "score": 0.025389546528458595,
+            "species": {
+                "scientificNameWithoutAuthor": "Pancratium illyricum",
+                "scientificNameAuthorship": "L.",
+                "genus": {
+                    "scientificNameWithoutAuthor": "Pancratium",
+                    "scientificNameAuthorship": ""
+                },
+                "family": {
+                    "scientificNameWithoutAuthor": "Amaryllidaceae",
+                    "scientificNameAuthorship": ""
+                },
+                "commonNames": ["Pancrace d'Illyrie", "Pancrais d'Illyrie"]
+            },
+            "images": [{
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/697b37ebcc41e9d9dc7eb1a24e6b137282be28fa",
+                        "m": "https://bs.floristic.org/v1/image/m/697b37ebcc41e9d9dc7eb1a24e6b137282be28fa",
+                        "s": "https://bs.floristic.org/v1/image/s/697b37ebcc41e9d9dc7eb1a24e6b137282be28fa"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi/ Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/5102f9428640d5533a47441e6c0ed19e9028240c",
+                        "m": "https://bs.floristic.org/v1/image/m/5102f9428640d5533a47441e6c0ed19e9028240c",
+                        "s": "https://bs.floristic.org/v1/image/s/5102f9428640d5533a47441e6c0ed19e9028240c"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/483e225b301a49bb8f04285f9a5cf454126a6a53",
+                        "m": "https://bs.floristic.org/v1/image/m/483e225b301a49bb8f04285f9a5cf454126a6a53",
+                        "s": "https://bs.floristic.org/v1/image/s/483e225b301a49bb8f04285f9a5cf454126a6a53"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/98f130f411f88dfbc854d7bcb19e97dee7a0cc91",
+                        "m": "https://bs.floristic.org/v1/image/m/98f130f411f88dfbc854d7bcb19e97dee7a0cc91",
+                        "s": "https://bs.floristic.org/v1/image/s/98f130f411f88dfbc854d7bcb19e97dee7a0cc91"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "habit",
+                    "author": "Tela Botanica − Christophe GIROD",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1370560275000,
+                        "string": "7 juin 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/8b1fa325e913eea51e8f2537244d9753194f19b6",
+                        "m": "https://bs.floristic.org/v1/image/m/8b1fa325e913eea51e8f2537244d9753194f19b6",
+                        "s": "https://bs.floristic.org/v1/image/s/8b1fa325e913eea51e8f2537244d9753194f19b6"
+                    },
+                    "citation": "Tela Botanica − Christophe GIROD / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "habit",
+                    "author": "Tela Botanica − Christophe GIROD",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1370560275000,
+                        "string": "7 juin 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/466449560a1901494fd61215e5134d1fcb76875f",
+                        "m": "https://bs.floristic.org/v1/image/m/466449560a1901494fd61215e5134d1fcb76875f",
+                        "s": "https://bs.floristic.org/v1/image/s/466449560a1901494fd61215e5134d1fcb76875f"
+                    },
+                    "citation": "Tela Botanica − Christophe GIROD / Pl@ntNet, cc-by-sa"
+                }
+            ],
+            "gbif": {
+                "id": "2853249"
+            }
+        }, {
+            "score": 0.018649350851774216,
+            "species": {
+                "scientificNameWithoutAuthor": "Ornithogalum nutans",
+                "scientificNameAuthorship": "L.",
+                "genus": {
+                    "scientificNameWithoutAuthor": "Ornithogalum",
+                    "scientificNameAuthorship": ""
+                },
+                "family": {
+                    "scientificNameWithoutAuthor": "Asparagaceae",
+                    "scientificNameAuthorship": ""
+                },
+                "commonNames": ["Ornithogale penché", "Ornithogale à fleurs penchées"]
+            },
+            "images"
+            : [{
+                    "organ": "flower",
+                    "author": "EOL − Meneerke bloem",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324774,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/7a66ca0aa93421c470183002efe58f63d3893ede",
+                        "m": "https://bs.floristic.org/v1/image/m/7a66ca0aa93421c470183002efe58f63d3893ede",
+                        "s": "https://bs.floristic.org/v1/image/s/7a66ca0aa93421c470183002efe58f63d3893ede"
+                    },
+                    "citation": "EOL − Meneerke bloem / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "EOL − Encyclopedia of Life",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324775,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/9406804a4b04e9b3689c4be0246520eacfa23018",
+                        "m": "https://bs.floristic.org/v1/image/m/9406804a4b04e9b3689c4be0246520eacfa23018",
+                        "s": "https://bs.floristic.org/v1/image/s/9406804a4b04e9b3689c4be0246520eacfa23018"
+                    },
+                    "citation": "EOL − Encyclopedia of Life / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "EOL − Meneerke bloem",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324774,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/c00331ef1d64af13d428d913ba8aeabad866e987",
+                        "m": "https://bs.floristic.org/v1/image/m/c00331ef1d64af13d428d913ba8aeabad866e987",
+                        "s": "https://bs.floristic.org/v1/image/s/c00331ef1d64af13d428d913ba8aeabad866e987"
+                    },
+                    "citation": "EOL − Meneerke bloem / Pl@ntNet, cc-by-sa"
+                }, {
+                    "organ": "flower",
+                    "author": "EOL − Meneerke bloem",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324775,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/61801f28c542a59912b67823925ea4b8187d7fa7",
+                        "m": "https://bs.floristic.org/v1/image/m/61801f28c542a59912b67823925ea4b8187d7fa7",
+                        "s": "https://bs.floristic.org/v1/image/s/61801f28c542a59912b67823925ea4b8187d7fa7"
+                    },
+                    "citation": "EOL − Meneerke bloem / Pl@ntNet, cc-by-sa"
+                }
+            ],
+            "gbif": {
+                "id": "2773281"
+            }
+        }
+    ],
+    "remainingIdentificationRequests": 44
+}

--- a/core/data/plantNetFrenchResponse2.json
+++ b/core/data/plantNetFrenchResponse2.json
@@ -1,0 +1,216 @@
+{
+    "query": {
+        "project": "best",
+        "images": [
+            "https://pbs.twimg.com/media/EIxl61NWoAA4gQ7?format=jpg&name=4096x4096",
+            "https://pbs.twimg.com/media/EIxl61NWoAA4gQ7?format=jpg&name=4096x4096"
+        ],
+        "organs": [
+            "flower",
+            "leaf"
+        ]
+    },
+    "language": "fr",
+    "preferedReferential": "the-plant-list",
+    "results": [
+        {
+            "score": 0.025389546528458595,
+            "species": {
+                "scientificNameWithoutAuthor": "Pancratium illyricum",
+                "scientificNameAuthorship": "L.",
+                "genus": {
+                    "scientificNameWithoutAuthor": "Pancratium",
+                    "scientificNameAuthorship": ""
+                },
+                "family": {
+                    "scientificNameWithoutAuthor": "Amaryllidaceae",
+                    "scientificNameAuthorship": ""
+                },
+                "commonNames": [
+                    "Pancrace d'Illyrie",
+                    "Pancrais d'Illyrie"
+                ]
+            },
+            "images": [
+                {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/697b37ebcc41e9d9dc7eb1a24e6b137282be28fa",
+                        "m": "https://bs.floristic.org/v1/image/m/697b37ebcc41e9d9dc7eb1a24e6b137282be28fa",
+                        "s": "https://bs.floristic.org/v1/image/s/697b37ebcc41e9d9dc7eb1a24e6b137282be28fa"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi/ Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/5102f9428640d5533a47441e6c0ed19e9028240c",
+                        "m": "https://bs.floristic.org/v1/image/m/5102f9428640d5533a47441e6c0ed19e9028240c",
+                        "s": "https://bs.floristic.org/v1/image/s/5102f9428640d5533a47441e6c0ed19e9028240c"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi / Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/483e225b301a49bb8f04285f9a5cf454126a6a53",
+                        "m": "https://bs.floristic.org/v1/image/m/483e225b301a49bb8f04285f9a5cf454126a6a53",
+                        "s": "https://bs.floristic.org/v1/image/s/483e225b301a49bb8f04285f9a5cf454126a6a53"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi / Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "flower",
+                    "author": "Tela Botanica − Liliane Roubaudi",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1363254029000,
+                        "string": "14 mars 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/98f130f411f88dfbc854d7bcb19e97dee7a0cc91",
+                        "m": "https://bs.floristic.org/v1/image/m/98f130f411f88dfbc854d7bcb19e97dee7a0cc91",
+                        "s": "https://bs.floristic.org/v1/image/s/98f130f411f88dfbc854d7bcb19e97dee7a0cc91"
+                    },
+                    "citation": "Tela Botanica − Liliane Roubaudi / Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "habit",
+                    "author": "Tela Botanica − Christophe GIROD",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1370560275000,
+                        "string": "7 juin 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/8b1fa325e913eea51e8f2537244d9753194f19b6",
+                        "m": "https://bs.floristic.org/v1/image/m/8b1fa325e913eea51e8f2537244d9753194f19b6",
+                        "s": "https://bs.floristic.org/v1/image/s/8b1fa325e913eea51e8f2537244d9753194f19b6"
+                    },
+                    "citation": "Tela Botanica − Christophe GIROD / Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "habit",
+                    "author": "Tela Botanica − Christophe GIROD",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1370560275000,
+                        "string": "7 juin 2013"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/466449560a1901494fd61215e5134d1fcb76875f",
+                        "m": "https://bs.floristic.org/v1/image/m/466449560a1901494fd61215e5134d1fcb76875f",
+                        "s": "https://bs.floristic.org/v1/image/s/466449560a1901494fd61215e5134d1fcb76875f"
+                    },
+                    "citation": "Tela Botanica − Christophe GIROD / Pl@ntNet, cc-by-sa"
+                }
+            ],
+            "gbif": {
+                "id": "2853249"
+            }
+        },
+        {
+            "score": 0.018649350851774216,
+            "species": {
+                "scientificNameWithoutAuthor": "Ornithogalum nutans",
+                "scientificNameAuthorship": "L.",
+                "genus": {
+                    "scientificNameWithoutAuthor": "Ornithogalum",
+                    "scientificNameAuthorship": ""
+                },
+                "family": {
+                    "scientificNameWithoutAuthor": "Asparagaceae",
+                    "scientificNameAuthorship": ""
+                },
+                "commonNames": [
+                    "Ornithogale penché",
+                    "Ornithogale à fleurs penchées"
+                ]
+            },
+            "images": [
+                {
+                    "organ": "flower",
+                    "author": "EOL − Meneerke bloem",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324774,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/7a66ca0aa93421c470183002efe58f63d3893ede",
+                        "m": "https://bs.floristic.org/v1/image/m/7a66ca0aa93421c470183002efe58f63d3893ede",
+                        "s": "https://bs.floristic.org/v1/image/s/7a66ca0aa93421c470183002efe58f63d3893ede"
+                    },
+                    "citation": "EOL − Meneerke bloem / Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "flower",
+                    "author": "EOL − Encyclopedia of Life",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324775,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/9406804a4b04e9b3689c4be0246520eacfa23018",
+                        "m": "https://bs.floristic.org/v1/image/m/9406804a4b04e9b3689c4be0246520eacfa23018",
+                        "s": "https://bs.floristic.org/v1/image/s/9406804a4b04e9b3689c4be0246520eacfa23018"
+                    },
+                    "citation": "EOL − Encyclopedia of Life / Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "flower",
+                    "author": "EOL − Meneerke bloem",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324774,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/c00331ef1d64af13d428d913ba8aeabad866e987",
+                        "m": "https://bs.floristic.org/v1/image/m/c00331ef1d64af13d428d913ba8aeabad866e987",
+                        "s": "https://bs.floristic.org/v1/image/s/c00331ef1d64af13d428d913ba8aeabad866e987"
+                    },
+                    "citation": "EOL − Meneerke bloem / Pl@ntNet, cc-by-sa"
+                },
+                {
+                    "organ": "flower",
+                    "author": "EOL − Meneerke bloem",
+                    "license": "cc-by-sa",
+                    "date": {
+                        "timestamp": 1482271324775,
+                        "string": "20 décembre 2016"
+                    },
+                    "url": {
+                        "o": "https://bs.floristic.org/v1/image/o/61801f28c542a59912b67823925ea4b8187d7fa7",
+                        "m": "https://bs.floristic.org/v1/image/m/61801f28c542a59912b67823925ea4b8187d7fa7",
+                        "s": "https://bs.floristic.org/v1/image/s/61801f28c542a59912b67823925ea4b8187d7fa7"
+                    },
+                    "citation": "EOL − Meneerke bloem / Pl@ntNet, cc-by-sa"
+                }
+            ],
+            "gbif": {
+                "id": "2773281"
+            }
+        }
+    ],
+    "remainingIdentificationRequests": 44
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botEnTrain",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Twitter botEnTrain",
   "main": "bet.js",
   "scripts": {
@@ -28,6 +28,7 @@
     "express": "^4.17.1",
     "fs": "0.0.1-security",
     "log4js": "^0.6.28",
+    "superagent": "^5.2.2",
     "twit": "^2.2.11"
   }
 }

--- a/plugins/FilmBTP.js
+++ b/plugins/FilmBTP.js
@@ -18,6 +18,10 @@ class FilmBTP {
     }
   }
 
+  getName() {
+    return "FilmBTP";
+  }
+
   getPluginTags() {
     return ["#BetFilm","#RepliquesDeFilms"];
   }
@@ -81,8 +85,9 @@ class FilmBTP {
     let noRetweet = " -filter:retweets";
     let fromMe = " from:botEnTrain1";
     let notMe = " -from:botEnTrain1";
+    let extendedMode = true;
     let searchQueryFromMe = "\"" + behavior.reply + "\"" + noRetweet + fromMe;
-    plugin.twitterClient.search(searchQueryFromMe, 200, (err,tweets) => {
+    plugin.twitterClient.search(searchQueryFromMe, 200, !extendedMode, (err,tweets) => {
         let mentioned = [];
         if (!err) {// get already mentioned users
             tweets.forEach((t) => {
@@ -101,7 +106,7 @@ class FilmBTP {
         mentioned.forEach((mentionedUser) => {// exclude alreadyMentioned
             searchQueryNotMe += " -from:" + mentionedUser;
         });
-        plugin.twitterClient.search(searchQueryNotMe, 20, cb);
+        plugin.twitterClient.search(searchQueryNotMe, 20, !extendedMode, cb);
     });
   }
 

--- a/plugins/PlantnetBTP.js
+++ b/plugins/PlantnetBTP.js
@@ -1,0 +1,203 @@
+/*jshint esversion: 6 */
+const log4js = require('log4js');
+
+const PLANTNET_MINIMAL_PERCENT = 60;
+const PLANTNET_MINIMAL_RATIO = PLANTNET_MINIMAL_PERCENT / 100;
+
+class PlantnetBTP {
+  constructor(twitterClient, plantnetClient) {
+    this.isAvailable = false;
+    this.logger = log4js.getLogger();
+    this.logger.setLevel('DEBUG'); // DEBUG will show search results
+    this.twitterClient = twitterClient;
+    this.plantnetClient = plantnetClient;
+    try {
+        this.isAvailable = plantnetClient.isReady();
+        this.logInfo(this.isAvailable ? "available" : "not available");
+    } catch (exception) {
+        this.logError(exception);
+    }
+  }
+
+  getName() {
+    return "PlantnetBTP";
+  }
+
+  getPluginTags() {
+    return ["#BetPlantnet","#IndentificationDePlantes"];
+  }
+
+  isReady() {
+    return this.isAvailable;
+  }
+
+  process(doSimulate, cb) {
+    let question = "(\"quelle est cette plante\" OR \"quelle est cette fleur\")";
+    let noArbre = " -arbre";
+    let withImage = " filter:media filter:images";
+    let plantnetSearch = question + noArbre + withImage;
+    this.searchTweets(plantnetSearch, (err, tweets) => {
+        if (err) {
+            this.logError(err);
+            cb({ "message": "impossible de chercher des tweets", "status": 500});
+            return;
+        }
+        /*
+        let debugLog = "";
+        tweets.forEach((t) => {
+            debugLog += "\n\t" + this.twitterClient.tweetLinkOf(t) + "\n\t\t" + this.twitterClient.tweetInfoOf(t);
+            // debugLog += JSON.stringify(t) ;
+        });
+        this.logDebug("search results " + debugLog);
+        */
+        let tweetCandidate = this.randomFromArray(tweets);
+        if (!tweetCandidate) {
+            cb({ "message": "aucun candidat pour pl@ntnet",
+                 "status": 202});
+            return;
+        }
+        let candidateImage = this.twitterClient.tweetFirstMediaUrl(tweetCandidate);
+        this.logDebug("tweetCandidate : " +
+            this.twitterClient.tweetLinkOf(tweetCandidate) + "\n\t" +
+            this.twitterClient.tweetInfoOf(tweetCandidate) + "\n\t" +
+            "first media url : " + candidateImage + "\n");
+
+        if (!candidateImage) {
+            cb({ "message": "aucune image pour pl@ntnet dans" + this.twitterClient.tweetLinkOf(tweetCandidate),
+                 "status": 202});
+            return;
+        }
+        this.logDebug("candidateImage : " + candidateImage);
+
+        this.plantnetClient.identify(candidateImage, doSimulate, (err, plantResult) => {
+            if (err) {
+                this.logError(err);
+                cb({"message": "impossible d'identifier l'image", "status": 500});
+                return;
+            }
+
+            // this.logDebug("plantnetResult : " + JSON.stringify(plantResult));
+
+            let firstScoredResult = this.plantnetClient.hasScoredResult(plantResult, PLANTNET_MINIMAL_RATIO);
+            if (!firstScoredResult) {
+                this.replyNoScoredResult(doSimulate, tweetCandidate, cb);
+                return;
+            }
+            this.replyScoredResult(doSimulate, tweetCandidate, firstScoredResult, cb);
+
+        }); // plantnetClient.identify end
+
+
+    });
+  }
+
+  replyScoredResult(doSimulate, tweetCandidate, firstScoredResult, cb) {
+      let illustrateImage = this.plantnetClient.resultImageOf(firstScoredResult);
+      let replyMessage = "Bonjour, j'ai interrogé Pl@ntnet pour tenter d'identifier votre première image" +
+      " et voici en résultat : \n" +
+      this.plantnetClient.resultInfoOf(firstScoredResult) + "\n" +
+      (illustrateImage ? "Avec en illustration: " + illustrateImage : "");
+
+      this.replyTweet(doSimulate, tweetCandidate, replyMessage, (err, replyTweet) => {
+          if (err) {
+              this.logError(err);
+              cb({"message": "impossible de répondre au tweet", "status": 500});
+              return;
+          }
+          cb(false, {
+              "html": "<b>Tweet</b>: <div class=\"bg-info\">" +
+                  this.twitterClient.tweetHtmlOf(tweetCandidate) + "</div>" +
+                  "<b>Réponse émise</b>: " +
+                  this.twitterClient.tweetHtmlOf(replyTweet),
+              "text": "\nTweet:\n\t" +
+                  this.twitterClient.tweetLinkOf(tweetCandidate) + "\n\t" +
+                  this.twitterClient.tweetInfoOf(tweetCandidate) + "\n" +
+                  "Reply sent:\n\t" +
+                  this.twitterClient.tweetLinkOf(replyTweet) + "\n\t" +
+                  this.twitterClient.tweetInfoOf(replyTweet) + "\n"
+          });
+      });
+  }
+
+  replyNoScoredResult(doSimulate, tweetCandidate, cb) {
+      let replyMessage = "Bonjour, j'ai interrogé Pl@ntnet pour tenter d'identifier votre première image" +
+      " mais cela n'a pas donné de résultat concluant (score>" + PLANTNET_MINIMAL_PERCENT + "%).\n:(\n";
+      this.replyTweet(doSimulate, tweetCandidate, replyMessage, (err, replyTweet) => {
+          if (err) {
+              this.logError(err);
+              cb({"message": "impossible de répondre au tweet", "status": 500});
+              return;
+          }
+          cb(false, {
+              "html": "<b>Tweet</b>: <div class=\"bg-info\">" +
+                  this.twitterClient.tweetHtmlOf(tweetCandidate) + "</div>" +
+                  "<b>Réponse émise</b>: " +
+                  this.twitterClient.tweetHtmlOf(replyTweet),
+              "text": "\nTweet:\n\t" +
+                  this.twitterClient.tweetLinkOf(tweetCandidate) + "\n\t" +
+                  this.twitterClient.tweetInfoOf(tweetCandidate) + "\n" +
+                  "Reply sent:\n\t" +
+                  this.twitterClient.tweetLinkOf(replyTweet) + "\n\t" +
+                  this.twitterClient.tweetInfoOf(replyTweet) + "\n"
+          });
+      });
+  }
+
+  searchTweets(plantnetSearch, cb) {
+    let plugin = this;
+    let noRetweet = " -filter:retweets";
+    let fromMe = " from:botEnTrain1";
+    let notMe = " -from:botEnTrain1";
+    let searchQueryFromMe = this.getPluginTags()[0] + noRetweet + fromMe;
+    let extendedMode = true;
+    plugin.twitterClient.search(searchQueryFromMe, 200, !extendedMode, (err,tweets) => {
+        let mentioned = [];
+        if (!err) {// get already mentioned users
+            tweets.forEach((t) => {
+                if (!t.entities || !t.entities.user_mentions) {
+                  return;
+                }
+                t.entities.user_mentions.forEach((mention) => {
+                    mentioned.push(mention.screen_name);
+                });
+            });
+            if (plugin.arrayWithContent(mentioned)) {
+              plugin.logDebug("Exclude already mentioned users => " + mentioned.join(', '));
+            }
+        }
+        let searchQueryNotMe = plantnetSearch + noRetweet + notMe;
+        mentioned.forEach((mentionedUser) => {// exclude alreadyMentioned
+            searchQueryNotMe += " -from:" + mentionedUser;
+        });
+        plugin.twitterClient.search(searchQueryNotMe, 20, extendedMode, cb);
+    });
+  }
+
+  replyTweet(doSimulate, tweet, message, cb) {
+    let replyMessage = message + "\n\n" + this.getPluginTags();
+    this.twitterClient.replyTo(tweet, replyMessage, doSimulate, cb);
+  }
+
+  randomFromArray(arr) {
+    if (!Array.isArray(arr) || arr.length <= 0) {
+        return undefined;
+    }
+    return arr[Math.floor(Math.random() * arr.length)];
+  }
+
+  arrayWithContent(arr) {
+    return (Array.isArray(arr) && arr.length > 0);
+  }
+
+  logDebug(msg) {
+    this.logger.debug(this.getPluginTags() + " | " + msg);
+  }
+  logInfo(msg) {
+    this.logger.info(this.getPluginTags() + " | " + msg);
+  }
+  logError(msg) {
+    this.logger.error(this.getPluginTags() + " | " + msg);
+  }
+}
+
+module.exports = PlantnetBTP;

--- a/scripts/doSimulatePN.sh
+++ b/scripts/doSimulatePN.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+curl -s \
+  -H "API-TOKEN: ${TOKEN_SIMULATION}" \
+  -H "PLUGIN-NAME: PlantnetBTP" \
+  http://localhost:5000/hook

--- a/scripts/env.template.sh
+++ b/scripts/env.template.sh
@@ -8,3 +8,5 @@ export ACCESS_TOKEN_SECRET_HERE=
 # BeT /hook API-TOKEN header secret values
 export TOKEN_SIMULATION=
 export TOKEN_ACTION=
+
+export MYPLANTNET_API_PRIVATE_KEY=


### PR DESCRIPTION
Fix #32 create PlantnetBTP

v1.1.0
- search twitter french question
- exclude already mentioned users (using dedicated query)
- extract a tweet candidate from search result
- extract image url from candidate
- make a plantnet query
- check score from plantnet result, and remove score less than 60%
- produce a reply to the original tweet that include : scientific name, common name, and image of the first score

NB- Plantnet identification is limited to 50 query per day