### PR TITLE
Fix #38 identification response too long

### DIFF
--- a/core/TwitterClient.js
+++ b/core/TwitterClient.js
@@ -1,7 +1,9 @@
 /*jshint esversion: 6 */
 const dateFormat = require('dateformat');
 const Twit = require('twit');
-var log4js = require('log4js');
+const log4js = require('log4js');
+
+const TWEET_MAX_LENGTH=280;
 
 class TwitterClient {
   constructor() {
@@ -71,14 +73,20 @@ class TwitterClient {
   }
 
   replyTo(tweet, replyMsg, doSimulate, cb) {
-      let replyStatus = '@' + tweet.user.screen_name + ' - ' + replyMsg;
+      let replyStatus = `@${tweet.user.screen_name} ${replyMsg}`;
+      let replyLength = replyStatus.length;
+      if (replyLength > TWEET_MAX_LENGTH) {
+        let cause = `(${replyStatus.length} > ${TWEET_MAX_LENGTH})`;
+        cb(`replyStatus too long ${cause} : ${replyStatus}`);
+        return;
+      }
       let params = {
         in_reply_to_status_id: tweet.id_str,
         status: replyStatus
       };
 
       this.logDebug("Uses params to reply to : " + JSON.stringify(params));
-      this.logInfo("Plan to reply to => " + this.tweetLinkOf(tweet));
+      this.logInfo(`Plan to reply(${replyLength}) to => ` + this.tweetLinkOf(tweet));
       this.logInfo(" " + this.tweetInfoOf(tweet));
 
       if (doSimulate) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botEnTrain",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Twitter botEnTrain",
   "main": "bet.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "fs": "0.0.1-security",
     "log4js": "^0.6.28",
     "superagent": "^5.2.2",
+    "tinyurl": "^1.1.5",
     "twit": "^2.2.11"
   }
 }

--- a/plugins/PlantnetBTP.js
+++ b/plugins/PlantnetBTP.js
@@ -3,6 +3,7 @@ const log4js = require('log4js');
 
 const PLANTNET_MINIMAL_PERCENT = 60;
 const PLANTNET_MINIMAL_RATIO = PLANTNET_MINIMAL_PERCENT / 100;
+const PLANTNET_SIMULATE = false;
 
 class PlantnetBTP {
   constructor(twitterClient, plantnetClient) {
@@ -69,7 +70,7 @@ class PlantnetBTP {
         }
         this.logDebug("candidateImage : " + candidateImage);
 
-        this.plantnetClient.identify(candidateImage, doSimulate, (err, plantResult) => {
+        this.plantnetClient.identify(candidateImage, PLANTNET_SIMULATE, (err, plantResult) => {
             if (err) {
                 this.logError(err);
                 cb({"message": "impossible d'identifier l'image", "status": 500});
@@ -92,11 +93,10 @@ class PlantnetBTP {
   }
 
   replyScoredResult(doSimulate, tweetCandidate, firstScoredResult, cb) {
-      let illustrateImage = this.plantnetClient.resultImageOf(firstScoredResult);
-      let replyMessage = "Bonjour, j'ai interrogé Pl@ntnet pour tenter d'identifier votre première image" +
-      " et voici en résultat : \n" +
+    this.plantnetClient.resultImageOf(firstScoredResult, (illustrateImage) => {
+      let replyMessage = "Pl@ntnet identifie " +
       this.plantnetClient.resultInfoOf(firstScoredResult) + "\n" +
-      (illustrateImage ? "Avec en illustration: " + illustrateImage : "");
+      (illustrateImage ? "\n\n" + illustrateImage : "");
 
       this.replyTweet(doSimulate, tweetCandidate, replyMessage, (err, replyTweet) => {
           if (err) {
@@ -117,6 +117,7 @@ class PlantnetBTP {
                   this.twitterClient.tweetInfoOf(replyTweet) + "\n"
           });
       });
+    });
   }
 
   replyNoScoredResult(doSimulate, tweetCandidate, cb) {


### PR DESCRIPTION
Fix #38 identification response too long

v1.1.1
use a shortest response when plantnet identification is a success
shorten image url